### PR TITLE
Schema - GetType: Replace constant "string" with function parameter

### DIFF
--- a/pkg/xsd/schema.go
+++ b/pkg/xsd/schema.go
@@ -230,7 +230,7 @@ func (sch *Schema) GetType(name string) Type {
 		}
 	}
 	if IsStaticType(name) {
-		return StaticType("string")
+		return StaticType(name)
 	}
 	return nil
 }

--- a/tests/xsd-examples/valid/xmldsig-core-schema.xsd.out
+++ b/tests/xsd-examples/valid/xmldsig-core-schema.xsd.out
@@ -418,7 +418,7 @@ type X509IssuerSerialType struct {
 
 	X509IssuerName string `xml:"X509IssuerName"`
 
-	X509SerialNumber string `xml:"X509SerialNumber"`
+	X509SerialNumber int64 `xml:"X509SerialNumber"`
 
 	InnerXml string `xml:",innerxml"`
 }


### PR DESCRIPTION
Schema GetType is always using "string" for StaticType, which is causing wrong results. 