### PR TITLE
Fix gosec failure: filepath pseudo sanitization

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -25,7 +25,7 @@ func GenerateTypes(schema *xsd.Schema, outputDir string) error {
 	if err != nil {
 		return err
 	}
-	goFile := fmt.Sprintf("%s/models.go", dir)
+	goFile := filepath.Clean(filepath.Join(dir, "models.go"))
 	fmt.Printf("\tGenerating '%s'\n", goFile)
 	f, err := os.Create(goFile)
 	if err != nil {


### PR DESCRIPTION
```
Addressing:
[/github/workspace/pkg/template/template.go:30] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
    29: 	fmt.Printf("\tGenerating '%s'\n", goFile)
  > 30: 	f, err := os.Create(goFile)
    31: 	if err != nil {
```