### PR TITLE
Add short/byte integer types

### DIFF
--- a/pkg/xsd/types.go
+++ b/pkg/xsd/types.go
@@ -275,6 +275,10 @@ var staticTypes = map[string]staticType{
 	"gDay":               "string",
 	"gMonth":             "string",
 	"time":               "string",
+	"unsignedShort":      "uint16",
+	"unsignedByte":       "uint8",
+	"short":              "int16",
+	"byte":               "int8",
 }
 
 func StaticType(name string) staticType {


### PR DESCRIPTION
I needed short/byte integer types as follows:

* xs:unsignedShort as uint16
* xs:unsignedByte as uint8
* xs:short as int16
* xs:byte as int8