### PR TITLE
ci lint: ignore teoretical xml tag name conflicts

### DIFF
--- a/.github/workflows/lint-golangci-lint.yaml
+++ b/.github/workflows/lint-golangci-lint.yaml
@@ -1,0 +1,5 @@
+linters-settings:
+  staticcheck:
+    checks:
+      - all
+      - '-SA5008'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -55,4 +55,4 @@ jobs:
         skip-go-installation: true
         skip-pkg-cache: true
         skip-build-cache: true
-        args: "--out-${NO_FUTURE}format colored-line-number"
+        args: "--out-${NO_FUTURE}format colored-line-number --config=./.github/workflows/lint-golangci-lint.yaml"


### PR DESCRIPTION
Addressing:
```
  Running [/home/runner/golangci-lint-1.55.2-linux-amd64/golangci-lint run --out-format=github-actions --out-${NO_FUTURE}format colored-line-number] in [] ...
  Error: pkg/xsd/attribute.go:18:28: SA5008: invalid XML tag: name "-" conflicts with name "attribute" in *github.com/gocomply/xsd2go/pkg/xsd.Attribute.XMLName (staticcheck)
  	refAttr        *Attribute `xml:"-"`
  	                          ^
  Error: pkg/xsd/attribute.go:20:28: SA5008: invalid XML tag: name "-" conflicts with name "schema" in *github.com/gocomply/xsd2go/pkg/xsd.Schema.XMLName (staticcheck)
  	schema         *Schema    `xml:"-"`
  	                          ^
  Error: pkg/xsd/attributegroup.go:15:31: SA5008: invalid XML tag: name "-" conflicts with name "schema" in *github.com/gocomply/xsd2go/pkg/xsd.Schema.XMLName (staticcheck)
  	schema           *Schema     `xml:"-"`
  	                             ^
  Error: pkg/xsd/choice.go:13:25: SA5008: invalid XML tag: name "-" conflicts with name "schema" in *github.com/gocomply/xsd2go/pkg/xsd.Schema.XMLName (staticcheck)
  	schema      *Schema    `xml:"-"`
  	                       ^
  Error: pkg/xsd/element.go:22:31: SA5008: invalid XML tag: name "-" conflicts with name "element" in *github.com/gocomply/xsd2go/pkg/xsd.Element.XMLName (staticcheck)
  	refElm          *Element     `xml:"-"`
  	                             ^
```