### PR TITLE
Add unsignedLong and hexBinary static types

### DIFF
--- a/pkg/xsd/types.go
+++ b/pkg/xsd/types.go
@@ -279,10 +279,12 @@ var staticTypes = map[string]staticType{
 	"gDay":               "string",
 	"gMonth":             "string",
 	"time":               "string",
+	"unsignedLong":       "uint64",
 	"unsignedShort":      "uint16",
 	"unsignedByte":       "uint8",
 	"short":              "int16",
 	"byte":               "int8",
+	"hexBinary":          "string",
 }
 
 func StaticType(name string) staticType {


### PR DESCRIPTION
I noticed that these two datatypes from XML Schema 1.0 were missing from the static type defintions whilst using xsd2go against the OfficeOpenXML xsds.   This PR adds them.  

Fixes #137 
Fixes #138 