### PR TITLE
fix: emit explicit element name instead of ",any" for single-element sequences

### DIFF
--- a/pkg/xsd/types.go
+++ b/pkg/xsd/types.go
@@ -25,12 +25,7 @@ func injectSchemaIntoAttributes(schema *Schema, intermAttributes []Attribute) []
 	return attributesWithProperScema
 }
 
-func setXmlNameAnyForSingleElements(elements []Element) []Element {
-	if len(elements) == 1 {
-		element := elements[0]
-		element.XmlNameOverride = ",any"
-		return []Element{element}
-	}
+func clearXmlNameOverrides(elements []Element) []Element {
 	for idx := range elements {
 		element := &elements[idx]
 		element.XmlNameOverride = ""
@@ -85,11 +80,11 @@ func (ct *ComplexType) Documentation() string {
 
 func (ct *ComplexType) Elements() []Element {
 	if ct.Sequence != nil {
-		return setXmlNameAnyForSingleElements(ct.Sequence.Elements())
+		return clearXmlNameOverrides(ct.Sequence.Elements())
 	} else if ct.SequenceAll != nil {
-		return setXmlNameAnyForSingleElements(ct.SequenceAll.Elements())
+		return clearXmlNameOverrides(ct.SequenceAll.Elements())
 	} else if ct.content != nil {
-		return setXmlNameAnyForSingleElements(ct.content.Elements())
+		return clearXmlNameOverrides(ct.content.Elements())
 	} else if ct.Choice != nil {
 		return ct.Choice.Elements()
 	}

--- a/tests/xsd-examples/valid/issue129.xsd.out
+++ b/tests/xsd-examples/valid/issue129.xsd.out
@@ -9,25 +9,25 @@ import (
 // Element
 type List struct {
 	XMLName xml.Name `xml:"List,omitempty"`
-	Ccc     []string `xml:",any"`
+	Ccc     []string `xml:"CCC"`
 }
 
 // Element
 type List1 struct {
 	XMLName xml.Name `xml:"List,omitempty"`
-	Ddd     []int    `xml:",any"`
+	Ddd     []int    `xml:"DDD"`
 }
 
 // XSD ComplexType declarations
 
 type Aaa struct {
 	XMLName xml.Name
-	List    *List `xml:",any,omitempty"`
+	List    *List `xml:"List,omitempty"`
 }
 
 type Bbb struct {
 	XMLName xml.Name
-	List    *List `xml:",any,omitempty"`
+	List    *List `xml:"List,omitempty"`
 }
 
 // XSD SimpleType declarations

--- a/tests/xsd-examples/valid/simple-8859-1.xsd.out
+++ b/tests/xsd-examples/valid/simple-8859-1.xsd.out
@@ -9,7 +9,7 @@ import (
 // Element
 type Myelement struct {
 	XMLName xml.Name `xml:"myelement"`
-	Id      int64    `xml:",any"`
+	Id      int64    `xml:"id"`
 }
 
 // XSD ComplexType declarations
@@ -17,7 +17,7 @@ type Myelement struct {
 // MyElementType: Documentation with a character from ISO-8859-1 encoding: ñ
 type MyElementType struct {
 	XMLName xml.Name
-	Id      int64 `xml:",any"`
+	Id      int64 `xml:"id"`
 }
 
 // XSD SimpleType declarations

--- a/tests/xsd-examples/valid/simple.xsd.out
+++ b/tests/xsd-examples/valid/simple.xsd.out
@@ -9,14 +9,14 @@ import (
 // Element
 type Myelement struct {
 	XMLName xml.Name `xml:"myelement"`
-	Id      int64    `xml:",any"`
+	Id      int64    `xml:"id"`
 }
 
 // XSD ComplexType declarations
 
 type MyElementType struct {
 	XMLName xml.Name
-	Id      int64 `xml:",any"`
+	Id      int64 `xml:"id"`
 }
 
 // XSD SimpleType declarations

--- a/tests/xsd-examples/valid/without_targetNamespace.xsd.out
+++ b/tests/xsd-examples/valid/without_targetNamespace.xsd.out
@@ -15,7 +15,7 @@ type Name struct {
 // Element
 type Referencingthename struct {
 	XMLName xml.Name `xml:"referencingthename"`
-	Name    string   `xml:",any"`
+	Name    string   `xml:"name"`
 }
 
 // XSD ComplexType declarations

--- a/tests/xsd-examples/valid/xmldsig-core-schema.xsd.out
+++ b/tests/xsd-examples/valid/xmldsig-core-schema.xsd.out
@@ -42,7 +42,7 @@ type CanonicalizationMethod struct {
 type SignatureMethod struct {
 	XMLName          xml.Name              `xml:"SignatureMethod"`
 	Algorithm        string                `xml:"Algorithm,attr"`
-	HmacoutputLength *HmacoutputLengthType `xml:",any,omitempty"`
+	HmacoutputLength *HmacoutputLengthType `xml:"HMACOutputLength,omitempty"`
 }
 
 // Element
@@ -59,7 +59,7 @@ type Reference struct {
 // Element
 type Transforms struct {
 	XMLName   xml.Name        `xml:"Transforms"`
-	Transform []TransformType `xml:",any"`
+	Transform []TransformType `xml:"Transform"`
 }
 
 // Element
@@ -118,7 +118,7 @@ type RetrievalMethod struct {
 	XMLName    xml.Name        `xml:"RetrievalMethod"`
 	Uri        string          `xml:"URI,attr,omitempty"`
 	Type       string          `xml:"Type,attr,omitempty"`
-	Transforms *TransformsType `xml:",any,omitempty"`
+	Transforms *TransformsType `xml:"Transforms,omitempty"`
 }
 
 // Element
@@ -141,7 +141,7 @@ type Pgpdata struct {
 // Element
 type Spkidata struct {
 	XMLName  xml.Name `xml:"SPKIData"`
-	Spkisexp string   `xml:",any"`
+	Spkisexp string   `xml:"SPKISexp"`
 }
 
 // Element
@@ -156,14 +156,14 @@ type Object struct {
 type Manifest struct {
 	XMLName   xml.Name        `xml:"Manifest"`
 	Id        string          `xml:"Id,attr,omitempty"`
-	Reference []ReferenceType `xml:",any"`
+	Reference []ReferenceType `xml:"Reference"`
 }
 
 // Element
 type SignatureProperties struct {
 	XMLName           xml.Name                `xml:"SignatureProperties"`
 	Id                string                  `xml:"Id,attr,omitempty"`
-	SignatureProperty []SignaturePropertyType `xml:",any"`
+	SignatureProperty []SignaturePropertyType `xml:"SignatureProperty"`
 }
 
 // Element
@@ -222,7 +222,7 @@ type CanonicalizationMethodType struct {
 type SignatureMethodType struct {
 	XMLName          xml.Name
 	Algorithm        string                `xml:"Algorithm,attr"`
-	HmacoutputLength *HmacoutputLengthType `xml:",any,omitempty"`
+	HmacoutputLength *HmacoutputLengthType `xml:"HMACOutputLength,omitempty"`
 	InnerXml         string                `xml:",innerxml"`
 }
 
@@ -238,7 +238,7 @@ type ReferenceType struct {
 
 type TransformsType struct {
 	XMLName   xml.Name
-	Transform []TransformType `xml:",any"`
+	Transform []TransformType `xml:"Transform"`
 }
 
 type TransformType struct {
@@ -278,7 +278,7 @@ type RetrievalMethodType struct {
 	XMLName    xml.Name
 	Uri        string          `xml:"URI,attr,omitempty"`
 	Type       string          `xml:"Type,attr,omitempty"`
-	Transforms *TransformsType `xml:",any,omitempty"`
+	Transforms *TransformsType `xml:"Transforms,omitempty"`
 }
 
 type X509DataType struct {
@@ -304,7 +304,7 @@ type PgpdataType struct {
 
 type SpkidataType struct {
 	XMLName  xml.Name
-	Spkisexp string `xml:",any"`
+	Spkisexp string `xml:"SPKISexp"`
 }
 
 type ObjectType struct {
@@ -318,13 +318,13 @@ type ObjectType struct {
 type ManifestType struct {
 	XMLName   xml.Name
 	Id        string          `xml:"Id,attr,omitempty"`
-	Reference []ReferenceType `xml:",any"`
+	Reference []ReferenceType `xml:"Reference"`
 }
 
 type SignaturePropertiesType struct {
 	XMLName           xml.Name
 	Id                string                  `xml:"Id,attr,omitempty"`
-	SignatureProperty []SignaturePropertyType `xml:",any"`
+	SignatureProperty []SignaturePropertyType `xml:"SignatureProperty"`
 }
 
 type SignaturePropertyType struct {


### PR DESCRIPTION
Previously, when a complexType contained a sequence with exactly one element, the generator set xml:",any" on the struct field. This was intended to handle abstract elements, but applied to all single-element sequences including concrete, named elements.

This caused two problems:
- Marshaling lost the element wrapper (xml:",any" doesn't emit a tag)
- Unmarshaling accepted any element name, bypassing schema validation

This fix removes the single-element special case and always uses the element's actual name from the XSD. The xml:",any" tag should only be used for genuine xsd:any wildcards, which is not yet implemented.