### PR TITLE
Add NMTOKEN-type as string

### DIFF
--- a/pkg/xsd/types.go
+++ b/pkg/xsd/types.go
@@ -280,6 +280,7 @@ var staticTypes = map[string]staticType{
 	"token":              "string",
 	"Name":               "string",
 	"NCName":             "string",
+	"NMTOKEN":            "string",
 	"NMTOKENS":           "string",
 	"anySimpleType":      "string",
 	"anyType":            "string",


### PR DESCRIPTION
NMTOKEN is a single string-token (unlike NMTOKENS which are whitespace-delimited tokens), map it as Go-string. 

> Example of such case: https://github.com/BISONNL/NeTEx-NL
>
> netex-nl.xsd, netex-nl-basic.xsd, netex-nl-enums.xsd